### PR TITLE
Fix Raygun to not leak unexpected data.

### DIFF
--- a/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
+++ b/Mindscape.Raygun4Net.Core/Mindscape.Raygun4Net.Core.csproj
@@ -123,6 +123,8 @@
     <Compile Include="Builders\RaygunErrorMessageBuilder.cs" />
     <Compile Include="Messages\RaygunErrorMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RaygunClient.cs" />
+    <Compile Include="RaygunMessageBuilder.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mindscape.Raygun4Net.Core/RaygunClient.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunClient.cs
@@ -1,0 +1,485 @@
+﻿using Mindscape.Raygun4Net.Messages;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.IsolatedStorage;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+
+namespace Mindscape.Raygun4Net
+{
+    public class RaygunClient : RaygunClientBase
+  {
+    private readonly string _apiKey;
+    private readonly List<Type> _wrapperExceptions = new List<Type>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RaygunClient" /> class.
+    /// </summary>
+    /// <param name="apiKey">The API key.</param>
+    public RaygunClient(string apiKey)
+    {
+      _apiKey = apiKey;
+
+      _wrapperExceptions.Add(typeof(TargetInvocationException));
+
+      ThreadPool.QueueUserWorkItem(state => { SendStoredMessages(); });
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RaygunClient" /> class.
+    /// Uses the ApiKey specified in the config file.
+    /// </summary>
+    public RaygunClient()
+      : this(RaygunSettings.Settings.ApiKey)
+    {
+    }
+
+    protected bool ValidateApiKey()
+    {
+      if (string.IsNullOrEmpty(_apiKey))
+      {
+        System.Diagnostics.Debug.WriteLine("ApiKey has not been provided, exception will not be logged");
+        return false;
+      }
+      return true;
+    }
+
+    /// <summary>
+    /// Gets or sets the username/password credentials which are used to authenticate with the system default Proxy server, if one is set
+    /// and requires credentials.
+    /// </summary>
+    public ICredentials ProxyCredentials { get; set; }
+
+    /// <summary>
+    /// Gets or sets an IWebProxy instance which can be used to override the default system proxy server settings
+    /// </summary>
+    public IWebProxy WebProxy { get; set; }
+
+    /// <summary>
+    /// Adds a list of outer exceptions that will be stripped, leaving only the valuable inner exception.
+    /// This can be used when a wrapper exception, e.g. TargetInvocationException or HttpUnhandledException,
+    /// contains the actual exception as the InnerException. The message and stack trace of the inner exception will then
+    /// be used by Raygun for grouping and display. The above two do not need to be added manually,
+    /// but if you have other wrapper exceptions that you want stripped you can pass them in here.
+    /// </summary>
+    /// <param name="wrapperExceptions">Exception types that you want removed and replaced with their inner exception.</param>
+    public void AddWrapperExceptions(params Type[] wrapperExceptions)
+    {
+      foreach (Type wrapper in wrapperExceptions)
+      {
+        if (!_wrapperExceptions.Contains(wrapper))
+        {
+          _wrapperExceptions.Add(wrapper);
+        }
+      }
+    }
+
+    /// <summary>
+    /// Specifies types of wrapper exceptions that Raygun should send rather than stripping out and sending the inner exception.
+    /// This can be used to remove the default wrapper exceptions (TargetInvocationException and HttpUnhandledException).
+    /// </summary>
+    /// <param name="wrapperExceptions">Exception types that should no longer be stripped away.</param>
+    public void RemoveWrapperExceptions(params Type[] wrapperExceptions)
+    {
+      foreach (Type wrapper in wrapperExceptions)
+      {
+        _wrapperExceptions.Remove(wrapper);
+      }
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously, using the version number of the originating assembly.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    public override void Send(Exception exception)
+    {
+      Send(exception, null, (IDictionary)null, null);
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously specifying a list of string tags associated
+    /// with the message for identification. This uses the version number of the originating assembly.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    public void Send(Exception exception, IList<string> tags)
+    {
+      Send(exception, tags, (IDictionary)null, null);
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously specifying a list of string tags associated
+    /// with the message for identification, as well as sending a key-value collection of custom data.
+    /// This uses the version number of the originating assembly.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    public void Send(Exception exception, IList<string> tags, IDictionary userCustomData)
+    {
+      Send(exception, tags, userCustomData, null);
+    }
+
+    /// <summary>
+    /// Transmits an exception to Raygun.io synchronously specifying a list of string tags associated
+    /// with the message for identification, as well as sending a key-value collection of custom data.
+    /// This uses the version number of the originating assembly.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    /// <param name="userInfo">Information about the user including the identity string.</param>
+    public void Send(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo)
+    {
+      if (CanSend(exception))
+      {
+        Send(BuildMessage(exception, tags, userCustomData, userInfo, null));
+        FlagAsSent(exception);
+      }
+    }
+
+    /// <summary>
+    /// Asynchronously transmits a message to Raygun.io.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    public void SendInBackground(Exception exception)
+    {
+      SendInBackground(exception, null, (IDictionary)null, null);
+    }
+
+    /// <summary>
+    /// Asynchronously transmits an exception to Raygun.io.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    public void SendInBackground(Exception exception, IList<string> tags)
+    {
+      SendInBackground(exception, tags, (IDictionary)null, null);
+    }
+
+    /// <summary>
+    /// Asynchronously transmits an exception to Raygun.io.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    public void SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData)
+    {
+      SendInBackground(exception, tags, userCustomData, null);
+    }
+
+    /// <summary>
+    /// Asynchronously transmits an exception to Raygun.io.
+    /// </summary>
+    /// <param name="exception">The exception to deliver.</param>
+    /// <param name="tags">A list of strings associated with the message.</param>
+    /// <param name="userCustomData">A key-value collection of custom data that will be added to the payload.</param>
+    /// <param name="userInfo">Information about the user including the identity string.</param>
+    public void SendInBackground(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfo)
+    {
+      if (CanSend(exception))
+      {
+        DateTime currentTime = DateTime.UtcNow;
+        
+        ThreadPool.QueueUserWorkItem(c =>
+        {
+          try
+          {
+            Send(BuildMessage(exception, tags, userCustomData, userInfo, currentTime));
+          }
+          catch (Exception)
+          {
+            // This will swallow any unhandled exceptions unless we explicitly want to throw on error.
+            // Otherwise this can bring the whole process down.
+            if (RaygunSettings.Settings.ThrowOnError)
+            {
+              throw;
+            }
+          }
+        });
+        FlagAsSent(exception);
+      }
+    }
+
+    /// <summary>
+    /// Asynchronously transmits a message to Raygun.io.
+    /// </summary>
+    /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
+    /// set to a valid DateTime and as much of the Details property as is available.</param>
+    public void SendInBackground(RaygunMessage raygunMessage)
+    {
+      ThreadPool.QueueUserWorkItem(c => Send(raygunMessage));
+    }
+
+    protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData)
+    {
+      return BuildMessage(exception, tags, userCustomData, null, null);
+    }
+
+    protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfoMessage)
+    {
+      return BuildMessage(exception, tags, userCustomData, userInfoMessage, null);
+    }
+
+    protected RaygunMessage BuildMessage(Exception exception, IList<string> tags, IDictionary userCustomData, RaygunIdentifierMessage userInfoMessage, DateTime? currentTime)
+    {
+      exception = StripWrapperExceptions(exception);
+
+      var message = RaygunMessageBuilder.New
+        .SetTimeStamp(currentTime)
+        .SetEnvironmentDetails()
+        .SetMachineName(Environment.MachineName)
+        .SetExceptionDetails(exception)
+        .SetClientDetails()
+        .SetVersion(ApplicationVersion)
+        .SetTags(tags)
+        .SetUserCustomData(userCustomData)
+        .SetUser(userInfoMessage ?? UserInfo ?? (!String.IsNullOrEmpty(User) ? new RaygunIdentifierMessage(User) : null))
+        .Build();
+
+      var customGroupingKey = OnCustomGroupingKey(exception, message);
+      if(string.IsNullOrEmpty(customGroupingKey) == false)
+      {
+        message.Details.GroupingKey = customGroupingKey;
+      }
+      return message;
+    }
+
+    private Exception StripWrapperExceptions(Exception exception)
+    {
+      if (exception != null && _wrapperExceptions.Any(wrapperException => exception.GetType() == wrapperException && exception.InnerException != null))
+      {
+        return StripWrapperExceptions(exception.InnerException);
+      }
+
+      return exception;
+    }
+
+    /// <summary>
+    /// Posts a RaygunMessage to the Raygun.io api endpoint.
+    /// </summary>
+    /// <param name="raygunMessage">The RaygunMessage to send. This needs its OccurredOn property
+    /// set to a valid DateTime and as much of the Details property as is available.</param>
+    public override void Send(RaygunMessage raygunMessage)
+    {
+      bool canSend = OnSendingMessage(raygunMessage);
+      if (canSend)
+      {
+        string message = null;
+        try
+        {
+          message = SimpleJson.SerializeObject(raygunMessage);
+        }
+        catch (Exception ex)
+        {
+          System.Diagnostics.Trace.WriteLine(string.Format("Error serializing exception {0}", ex.Message));
+
+          if (RaygunSettings.Settings.ThrowOnError)
+          {
+            throw;
+          }
+        }
+
+        if (message != null)
+        {
+          try
+          {
+            Send(message);
+          }
+          catch (Exception ex)
+          {
+            SaveMessage(message);
+            System.Diagnostics.Trace.WriteLine(string.Format("Error Logging Exception to Raygun.io {0}", ex.Message));
+
+            if (RaygunSettings.Settings.ThrowOnError)
+            {
+              throw;
+            }
+          }
+
+          SendStoredMessages();
+        }
+      }
+    }
+
+    private void Send(string message)
+    {
+      if (ValidateApiKey())
+      {
+        using (var client = CreateWebClient())
+        {
+          client.UploadString(RaygunSettings.Settings.ApiEndpoint, message);
+        }
+      }
+    }
+
+    protected WebClient CreateWebClient()
+    {
+      var client = new WebClient();
+      client.Headers.Add("X-ApiKey", _apiKey);
+      client.Headers.Add("content-type", "application/json; charset=utf-8");
+      client.Encoding = System.Text.Encoding.UTF8;
+
+      if (WebProxy != null)
+      {
+        client.Proxy = WebProxy;
+      }
+      else if (WebRequest.DefaultWebProxy != null)
+      {
+        Uri proxyUri = WebRequest.DefaultWebProxy.GetProxy(new Uri(RaygunSettings.Settings.ApiEndpoint.ToString()));
+
+        if (proxyUri != null && proxyUri.AbsoluteUri != RaygunSettings.Settings.ApiEndpoint.ToString())
+        {
+          client.Proxy = new WebProxy(proxyUri, false);
+
+          if (ProxyCredentials == null)
+          {
+            client.UseDefaultCredentials = true;
+            client.Proxy.Credentials = CredentialCache.DefaultCredentials;
+          }
+          else
+          {
+            client.UseDefaultCredentials = false;
+            client.Proxy.Credentials = ProxyCredentials;
+          }
+        }
+      }
+      return client;
+    }
+
+    private void SaveMessage(string message)
+    {
+      try
+      {
+        using (IsolatedStorageFile isolatedStorage = GetIsolatedStorageScope())
+        {
+          string directoryName = "RaygunOfflineStorage";
+          string[] directories = isolatedStorage.GetDirectoryNames("*");
+          if (!FileExists(directories, directoryName))
+          {
+            isolatedStorage.CreateDirectory(directoryName);
+          }
+
+          int number = 1;
+          string[] files = isolatedStorage.GetFileNames(directoryName + "\\*.txt");
+          while (true)
+          {
+            bool exists = FileExists(files, "RaygunErrorMessage" + number + ".txt");
+            if (!exists)
+            {
+              string nextFileName = "RaygunErrorMessage" + (number + 1) + ".txt";
+              exists = FileExists(files, nextFileName);
+              if (exists)
+              {
+                isolatedStorage.DeleteFile(directoryName + "\\" + nextFileName);
+              }
+              break;
+            }
+            number++;
+          }
+
+          if (number == 11)
+          {
+            string firstFileName = "RaygunErrorMessage1.txt";
+            if (FileExists(files, firstFileName))
+            {
+              isolatedStorage.DeleteFile(directoryName + "\\" + firstFileName);
+            }
+          }
+          using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(directoryName + "\\RaygunErrorMessage" + number + ".txt", FileMode.OpenOrCreate, FileAccess.Write, isolatedStorage))
+          {
+            using (StreamWriter writer = new StreamWriter(isoStream, Encoding.Unicode))
+            {
+              writer.Write(message);
+              writer.Flush();
+              writer.Close();
+            }
+          }
+          System.Diagnostics.Trace.WriteLine("Saved message: " + "RaygunErrorMessage" + number + ".txt");
+        }
+      }
+      catch (Exception ex)
+      {
+        System.Diagnostics.Trace.WriteLine(string.Format("Error saving message to isolated storage {0}", ex.Message));
+      }
+    }
+
+    private bool FileExists(string[] files, string fileName)
+    {
+      foreach (string str in files)
+      {
+        if (fileName.Equals(str))
+        {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static object _sendLock = new object();
+
+    private void SendStoredMessages()
+    {
+      lock (_sendLock)
+      {
+        try
+        {
+          using (IsolatedStorageFile isolatedStorage = GetIsolatedStorageScope())
+          {
+            string directoryName = "RaygunOfflineStorage";
+            string[] directories = isolatedStorage.GetDirectoryNames("*");
+            if (FileExists(directories, directoryName))
+            {
+              string[] fileNames = isolatedStorage.GetFileNames(directoryName + "\\*.txt");
+              foreach (string name in fileNames)
+              {
+                IsolatedStorageFileStream isoFileStream = new IsolatedStorageFileStream(directoryName + "\\" + name, FileMode.Open, isolatedStorage);
+                using (StreamReader reader = new StreamReader(isoFileStream))
+                {
+                  string text = reader.ReadToEnd();
+                  try
+                  {
+                    Send(text);
+                  }
+                  catch
+                  {
+                    // If just one message fails to send, then don't delete the message, and don't attempt sending anymore until later.
+                    return;
+                  }
+                  System.Diagnostics.Debug.WriteLine("Sent " + name);
+                }
+                isolatedStorage.DeleteFile(directoryName + "\\" + name);
+              }
+              if (isolatedStorage.GetFileNames(directoryName + "\\*.txt").Length == 0)
+              {
+                System.Diagnostics.Debug.WriteLine("Successfully sent all pending messages");
+                isolatedStorage.DeleteDirectory(directoryName);
+              }
+            }
+          }
+        }
+        catch (Exception ex)
+        {
+          System.Diagnostics.Debug.WriteLine(string.Format("Error sending stored messages to Raygun.io {0}", ex.Message));
+        }
+      }
+    }
+
+    private IsolatedStorageFile GetIsolatedStorageScope()
+    {
+      if (AppDomain.CurrentDomain != null && AppDomain.CurrentDomain.ActivationContext != null)
+      {
+        return IsolatedStorageFile.GetUserStoreForApplication();
+      }
+      else
+      {
+        return IsolatedStorageFile.GetUserStoreForAssembly();
+      }
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.Core/RaygunMessageBuilder.cs
+++ b/Mindscape.Raygun4Net.Core/RaygunMessageBuilder.cs
@@ -1,0 +1,165 @@
+﻿using Mindscape.Raygun4Net.Builders;
+using Mindscape.Raygun4Net.Messages;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+
+namespace Mindscape.Raygun4Net
+{
+    public class RaygunMessageBuilder : IRaygunMessageBuilder
+  {
+    public static RaygunMessageBuilder New
+    {
+      get
+      {
+        return new RaygunMessageBuilder();
+      }
+    }
+
+    private readonly RaygunMessage _raygunMessage;
+
+    private RaygunMessageBuilder()
+    {
+      _raygunMessage = new RaygunMessage();
+    }
+
+    public RaygunMessage Build()
+    {
+      return _raygunMessage;
+    }
+
+    public IRaygunMessageBuilder SetMachineName(string machineName)
+    {
+      _raygunMessage.Details.MachineName = machineName;
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetEnvironmentDetails()
+    {
+      _raygunMessage.Details.Environment = RaygunEnvironmentMessageBuilder.Build();
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetExceptionDetails(Exception exception)
+    {
+      if (exception != null)
+      {
+        _raygunMessage.Details.Error = RaygunErrorMessageBuilder.Build(exception);
+      }
+
+      try
+      {
+        WebException webError = exception as WebException;
+        if (webError != null)
+        {
+          if (webError.Status == WebExceptionStatus.ProtocolError && webError.Response is HttpWebResponse)
+          {
+            HttpWebResponse response = (HttpWebResponse)webError.Response;
+            _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusCode = (int)response.StatusCode, StatusDescription = response.StatusDescription };
+          }
+          else if (webError.Status == WebExceptionStatus.ProtocolError && webError.Response is FtpWebResponse)
+          {
+            FtpWebResponse response = (FtpWebResponse)webError.Response;
+            _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusCode = (int)response.StatusCode, StatusDescription = response.StatusDescription };
+          }
+          else
+          {
+            _raygunMessage.Details.Response = new RaygunResponseMessage() { StatusDescription = webError.Status.ToString() };
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        System.Diagnostics.Trace.WriteLine("Error retrieving response info {0}", ex.Message);
+      }
+
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetClientDetails()
+    {
+      _raygunMessage.Details.Client = new RaygunClientMessage()
+      {
+        // RaygunClientMessage is in core, so this message builder overrides the Name to get the correct client name.
+        Name = ((AssemblyTitleAttribute)GetType().Assembly.GetCustomAttributes(typeof(AssemblyTitleAttribute), false)[0]).Title
+      };
+
+      // The MVC provider references the Raygun4Net4 provider, so this is a special case to get the correct client name:
+      var mvcAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Mindscape.Raygun4Net.Mvc"));
+      if (mvcAssembly != null)
+      {
+        _raygunMessage.Details.Client.Name = "Raygun4Net.Mvc";
+      }
+
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetUserCustomData(IDictionary userCustomData)
+    {
+      _raygunMessage.Details.UserCustomData = userCustomData;
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetTags(IList<string> tags)
+    {
+      _raygunMessage.Details.Tags = tags;
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetUser(RaygunIdentifierMessage user)
+    {
+      _raygunMessage.Details.User = user;
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetHttpDetails(RaygunRequestMessage message)
+    {
+      _raygunMessage.Details.Request = message;
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetVersion(string version)
+    {
+      if (!String.IsNullOrEmpty(version))
+      {
+        _raygunMessage.Details.Version = version;
+      }
+      else if (!String.IsNullOrEmpty(RaygunSettings.Settings.ApplicationVersion))
+      {
+        _raygunMessage.Details.Version = RaygunSettings.Settings.ApplicationVersion;
+      }
+      else
+      {
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly != null)
+        {
+          _raygunMessage.Details.Version = entryAssembly.GetName().Version.ToString();
+        }
+        else
+        {
+          _raygunMessage.Details.Version = "Not supplied";
+        }
+      }
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetTimeStamp(DateTime? currentTime)
+    {
+      if (currentTime != null)
+      {
+        _raygunMessage.OccurredOn = currentTime.Value;
+      }
+      return this;
+    }
+
+    public IRaygunMessageBuilder SetBreadcrumbs(List<RaygunBreadcrumb> breadcrumbs)
+    {
+      _raygunMessage.Details.Breadcrumbs = breadcrumbs;
+
+      return this;
+    }
+  }
+}

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -134,7 +134,7 @@ namespace Mindscape.Raygun4Net.WebApi
       }
 
       var owinAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Owin"));
-      if (owinAssembly == null)
+      if (owinAssembly == null && !RaygunSettings.Settings.IsRawDataIgnored)
       {
         config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
       }

--- a/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
+++ b/Mindscape.Raygun4Net.WebApi/RaygunWebApiClient.cs
@@ -26,6 +26,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
     private static RaygunWebApiExceptionFilter _exceptionFilter;
     private static RaygunWebApiActionFilter _actionFilter;
+    private static RaygunWebApiDelegatingHandler _delegatingHandler;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RaygunClientBase" /> class.
@@ -136,7 +137,8 @@ namespace Mindscape.Raygun4Net.WebApi
       var owinAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Owin"));
       if (owinAssembly == null && !RaygunSettings.Settings.IsRawDataIgnored)
       {
-        config.MessageHandlers.Add(new RaygunWebApiDelegatingHandler());
+        _delegatingHandler = new RaygunWebApiDelegatingHandler();
+        config.MessageHandlers.Add(_delegatingHandler);
       }
 
       var clientCreator = new RaygunWebApiClientProvider(generateRaygunClientWithMessage, applicationVersion);
@@ -173,6 +175,11 @@ namespace Mindscape.Raygun4Net.WebApi
           config.Services.RemoveAt(typeof(IExceptionLogger), exceptionLoggerIndex);
         }
 
+        if(_delegatingHandler != null)
+        {
+          config.MessageHandlers.Remove(_delegatingHandler);
+        }
+
         config.Filters.Remove(_exceptionFilter);
         config.Filters.Remove(_actionFilter);
 
@@ -196,6 +203,7 @@ namespace Mindscape.Raygun4Net.WebApi
 
         _exceptionFilter = null;
         _actionFilter = null;
+        _delegatingHandler = null;
       }
     }
 


### PR DESCRIPTION
* Enable `Mindscape.Raygun4Net.Core` to stand alone with a concrete implementation of `RaygunClientBase`.
* Fix Attach/Detach to track and properly add/remove the `RaygunWebApiDelegatingHandler`
* Fix Attach to only add the `RaygunWebApiDelegatingHandler` if request data is logged (`IsRawDataIgnored` is false).